### PR TITLE
Update README.md with qewd-server docker install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ See the Docker documentation, but here's some quick instructions:
 
       curl -sSL https://get.docker.com | sh
 
+## Install the qewd-server docker container
+
+Run the docker command to install the qewd-server docker container
+
+docker pull rtweed/qewd-server
+
 
 ## Installing the Example APIs
 


### PR DESCRIPTION
these set up instructions are missing a note to ensure the qewd-server container is installed and how to do it
so this edit adds that detail